### PR TITLE
Ensure that the ServiceAccount is created before init Job

### DIFF
--- a/templates/serviceaccount.yaml
+++ b/templates/serviceaccount.yaml
@@ -8,6 +8,9 @@ metadata:
     {{- include "boundary.labels" . | nindent 4 }}
   {{- with .Values.serviceAccount.annotations }}
   annotations:
+    helm.sh/hook: pre-install
+    helm.sh/hook-delete-policy: before-hook-creation
+    helm.sh/hook-weight: "-10"
     {{- toYaml . | nindent 4 }}
   {{- end }}
 {{- end }}


### PR DESCRIPTION
On an initial helm install, the database boundary-init Job will run on
a pre-install hook, meaning it tries to apply before the Resources are
created. Since it requires the ServiceAccount which itself is a Resource
this creates a chicken and egg situation.

This commit fixes that issue by also applying the ServiceAccount as a
pre-install hook before the boundary-init Job is created